### PR TITLE
Add update of page from datasource every 30s.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,11 @@
 $( document ).ready(function() {
     console.log( "ready!" );
     RenderParkingData();
+
+    setInterval(function() 
+    {
+      RenderParkingData();
+    }, 30000);
 });
 
 var carParkData =[];
@@ -21,6 +26,8 @@ function GetCarparkData(){
 }
 
 function RenderParkingData(){
+    $('#timestamp').html('Updating, please wait...');
+
     var data = data=GetCarparkData();
      //console.log(data);
      $('#poster').html('');
@@ -90,5 +97,11 @@ function RenderCarpark(data){
 
 function RenderTimestamp(data)
 {
-  $('#timestamp').html(data.carparkData.Timestamp);
+  var now = new Date();
+  var h = ('0' + now.getHours()).slice(-2);
+  var m = ('0' + now.getMinutes()).slice(-2);
+  var s = ('0' + now.getSeconds()).slice(-2);
+
+  var localstamp = 'Page last updated at ' + h + ':' + m + ':' + s + '.';
+  $('#timestamp').html(data.carparkData.Timestamp + '. ' + localstamp);
 }


### PR DESCRIPTION
Adds a quick bit of javascript to update the page every 30s. Also adds a second timestamp to the string at the top detailing when this last happened - suggest amending this so it's only got the one stamp, but not sure what's best? If we just use the car park data one, looks like it's not updating, but otherwise we give false impression that data is old.

Maybe say 'page last updated at h:m:s, number of spaces updated N minutes ago'?
